### PR TITLE
ID-2067 Cortex XSOAR 2.0: Palo Alto App Validation

### DIFF
--- a/Packs/DomainTools_Iris/IndicatorFields/indicatorfield-domaintoolsirisexpirationdate.json
+++ b/Packs/DomainTools_Iris/IndicatorFields/indicatorfield-domaintoolsirisexpirationdate.json
@@ -1,0 +1,31 @@
+{
+    "id": "indicator_domaintoolsirisexpirationdate",
+    "version": -1,
+    "modified": "2023-10-16T17:13:01.885961592Z",
+    "name": "DomainTools Iris Expiration Date",
+    "ownerOnly": false,
+    "cliName": "domaintoolsirisexpirationdate",
+    "type": "shortText",
+    "closeForm": false,
+    "editForm": true,
+    "required": false,
+    "neverSetAsRequired": false,
+    "isReadOnly": false,
+    "useAsKpi": false,
+    "locked": false,
+    "system": false,
+    "content": true,
+    "group": 2,
+    "hidden": false,
+    "openEnded": false,
+    "associatedTypes": [
+        "DomainTools Iris"
+    ],
+    "associatedToAll": false,
+    "unmapped": false,
+    "unsearchable": false,
+    "caseInsensitive": true,
+    "sla": 0,
+    "threshold": 72,
+    "fromVersion": "6.6.0"
+}

--- a/Packs/DomainTools_Iris/IndicatorFields/indicatorfield-domaintoolsirisriskscorecomponents.json
+++ b/Packs/DomainTools_Iris/IndicatorFields/indicatorfield-domaintoolsirisriskscorecomponents.json
@@ -24,7 +24,7 @@
     "caseInsensitive": true,
     "columns": [
         {
-            "key": "proximity",
+            "key": "ProximityRiskScore",
             "displayName": "Proximity",
             "type": "shortText",
             "required": true,
@@ -36,7 +36,7 @@
             "selectValues": null
         },
         {
-            "key": "phishing",
+            "key": "PhishingRiskScore",
             "displayName": "Phishing",
             "type": "shortText",
             "required": true,
@@ -48,7 +48,7 @@
             "selectValues": null
         },
         {
-            "key": "malware",
+            "key": "MalwareRiskScore",
             "displayName": "Malware",
             "type": "shortText",
             "required": false,
@@ -60,7 +60,7 @@
             "selectValues": null
         },
         {
-            "key": "spam",
+            "key": "SpamRiskScore",
             "displayName": "Spam",
             "type": "shortText",
             "required": true,
@@ -72,7 +72,7 @@
             "selectValues": null
         },
         {
-            "key": "evidence",
+            "key": "ThreatProfileRiskScore",
             "displayName": "Evidence",
             "type": "shortText",
             "required": true,

--- a/Packs/DomainTools_Iris/IndicatorTypes/reputations-Domaintools_Iris.json
+++ b/Packs/DomainTools_Iris/IndicatorTypes/reputations-Domaintools_Iris.json
@@ -1,39 +1,18 @@
 {
     "id": "DomainTools Iris",
-    "version": 4,
-    "cacheVersn": 0,
+    "version": -1,
     "modified": "2023-12-19T20:11:35.191562524Z",
-    "created": "2023-12-05T16:19:28.684636513Z",
-    "sizeInBytes": 0,
-    "packID": "",
-    "packName": "",
-    "itemVersion": "",
-    "fromServerVersion": "",
-    "toServerVersion": "",
-    "definitionId": "",
-    "prevName": "",
-    "vcShouldIgnore": false,
-    "vcShouldKeepItemLegacyProdMachine": false,
-    "commitMessage": "",
     "shouldCommit": false,
     "regex": "",
     "details": "DomainTools Iris",
     "prevDetails": "DomainTools Iris",
-    "legacyNames": null,
-    "reputationScriptName": "",
     "reputationCommand": "domain",
-    "enhancementScriptNames": [],
     "system": false,
     "locked": false,
     "disabled": false,
     "file": false,
     "updateAfter": 0,
     "mergeContext": false,
-    "formatScript": "",
-    "contextPath": "",
-    "contextValue": "",
-    "excludedBrands": [],
-    "defaultMapping": null,
     "manualMapping": {
         "domaintoolsirisadditionalwhoisemails": {
             "simple": "DomainTools.Identity.AdditionalWhoisEmails.value"
@@ -75,8 +54,7 @@
             "simple": "DomainTools.Registration.ExpirationDate"
         }
     },
-    "fileHashesPriority": null,
     "expiration": 0,
-    "shouldShareComments": false,
-    "layout": "DomainTools Iris Indicator Layout"
+    "layout": "DomainTools Iris Indicator Layout",
+    "fromVersion": "6.6.0"
 }

--- a/Packs/DomainTools_Iris/IndicatorTypes/reputations-Domaintools_Iris.json
+++ b/Packs/DomainTools_Iris/IndicatorTypes/reputations-Domaintools_Iris.json
@@ -1,19 +1,82 @@
 {
     "id": "DomainTools Iris",
-    "version": -1,
-    "modified": "2023-10-17T16:01:26.668022353Z",
+    "version": 4,
+    "cacheVersn": 0,
+    "modified": "2023-12-19T20:11:35.191562524Z",
+    "created": "2023-12-05T16:19:28.684636513Z",
+    "sizeInBytes": 0,
+    "packID": "",
+    "packName": "",
+    "itemVersion": "",
+    "fromServerVersion": "",
+    "toServerVersion": "",
+    "definitionId": "",
+    "prevName": "",
+    "vcShouldIgnore": false,
+    "vcShouldKeepItemLegacyProdMachine": false,
+    "commitMessage": "",
     "shouldCommit": false,
     "regex": "",
     "details": "DomainTools Iris",
     "prevDetails": "DomainTools Iris",
+    "legacyNames": null,
+    "reputationScriptName": "",
     "reputationCommand": "domain",
+    "enhancementScriptNames": [],
     "system": false,
     "locked": false,
     "disabled": false,
     "file": false,
     "updateAfter": 0,
     "mergeContext": false,
+    "formatScript": "",
+    "contextPath": "",
+    "contextValue": "",
+    "excludedBrands": [],
+    "defaultMapping": null,
+    "manualMapping": {
+        "domaintoolsirisadditionalwhoisemails": {
+            "simple": "DomainTools.Identity.AdditionalWhoisEmails.value"
+        },
+        "domaintoolsirisdomainage": {
+            "simple": "DomainTools.FirstSeen"
+        },
+        "domaintoolsirisemaildomains": {
+            "simple": "DomainTools.Identity.EmailDomains"
+        },
+        "domaintoolsirisfirstseen": {
+            "simple": "DomainTools.FirstSeen"
+        },
+        "domaintoolsirisipaddresses": {
+            "simple": "DomainTools.Hosting.IPAddresses.address.value"
+        },
+        "domaintoolsirisipcountrycode": {
+            "simple": "DomainTools.Hosting.IPAddresses.country_code.value"
+        },
+        "domaintoolsirismailservers": {
+            "simple": "DomainTools.Hosting.MailServers.domain.value"
+        },
+        "domaintoolsirisregistrantorg": {
+            "simple": "DomainTools.Identity.RegistrantContact.Org.value"
+        },
+        "domaintoolsirisriskscore": {
+            "simple": "DomainTools.Analytics.OverallRiskScore"
+        },
+        "domaintoolsirisriskscorecomponents": {
+            "simple": "DomainTools.Analytics"
+        },
+        "domaintoolsirissoaemail": {
+            "simple": "DomainTools.Identity.SOAEmail.value"
+        },
+        "domaintoolsiristags": {
+            "simple": "DomainTools.Analytics.Tags.label"
+        },
+        "domaintoolsirisexpirationdate": {
+            "simple": "DomainTools.Registration.ExpirationDate"
+        }
+    },
+    "fileHashesPriority": null,
     "expiration": 0,
-    "layout": "DomainTools Iris Indicator Layout",
-    "fromVersion": "6.6.0"
+    "shouldShareComments": false,
+    "layout": "DomainTools Iris Indicator Layout"
 }

--- a/Packs/DomainTools_Iris/Integrations/DomainTools_Iris/DomainTools_Iris.py
+++ b/Packs/DomainTools_Iris/Integrations/DomainTools_Iris/DomainTools_Iris.py
@@ -1599,6 +1599,8 @@ def main():
             test_module()
         elif demisto.command() == 'domain':
             domain_command()
+        elif demisto.command() == 'domaintoolsiris-investigate':
+            domain_command()
         elif demisto.command() == 'domaintoolsiris-analytics':
             domain_analytics_command()
         elif demisto.command() == 'domaintoolsiris-threat-profile':

--- a/Packs/DomainTools_Iris/Integrations/DomainTools_Iris/DomainTools_Iris.yml
+++ b/Packs/DomainTools_Iris/Integrations/DomainTools_Iris/DomainTools_Iris.yml
@@ -471,366 +471,366 @@ script:
     deprecated: false
     execution: false
   - arguments:
-      - default: true
-        description: The domain name (SLD.TLD) to Investigate. Supports up to 1,000 comma-separated domains.
-        name: domain
-        required: true
-        isArray: false
-        secret: false
-      - default: false
-        description: Include the investigate results in Context Data. Defaults to true.
-        isArray: false
-        name: include_context
-        required: false
-        secret: false
-        type: String
-        predefined:
-          - "true"
-          - "false"
-        auto: PREDEFINED
-        defaultValue: "true"
+    - description: The domain name (SLD.TLD) to Investigate. Supports up to 1,000 comma-separated domains.
+      name: domain
+      required: true
+      default: true
+      isArray: false
+      secret: false
+    - default: false
+      description: Include the investigate results in Context Data. Defaults to true.
+      isArray: false
+      name: include_context
+      required: false
+      secret: false
+      type: String
+      predefined:
+      - "true"
+      - "false"
+      auto: PREDEFINED
+      defaultValue: "true"
     description: Returns a complete profile of the domain (SLD.TLD) using Iris Investigate. If parsing of FQDNs is desired, see domainExtractAndInvestigate.
     name: domaintoolsiris-investigate
     outputs:
-      - contextPath: Domain.Name
-        description: The name of the domain.
-        type: String
-      - contextPath: Domain.DNS
-        description: The DNS of the domain.
-        type: String
-      - contextPath: Domain.DomainStatus
-        description: The status of the domain.
-        type: Boolean
-      - contextPath: Domain.CreationDate
-        description: The creation date.
-        type: Date
-      - contextPath: Domain.ExpirationDate
-        description: The expiration date of the domain.
-        type: Date
-      - contextPath: Domain.NameServers
-        description: The nameServers of the domain.
-        type: String
-      - contextPath: Domain.Registrant.Country
-        description: The registrant country of the domain.
-        type: String
-      - contextPath: Domain.Registrant.Email
-        description: The registrant email of the domain.
-        type: String
-      - contextPath: Domain.Registrant.Name
-        description: The registrant name of the domain.
-        type: String
-      - contextPath: Domain.Registrant.Phone
-        description: The registrant phone number of the domain.
-        type: String
-      - contextPath: Domain.Malicious.Vendor
-        description: The vendor who classified the domain as malicious.
-        type: String
-      - contextPath: Domain.Malicious.Description
-        description: The description as to why the domain was found to be malicious.
-        type: String
-      - contextPath: DomainTools.Name
-        description: The domain name in DomainTools.
-        type: String
-      - contextPath: DomainTools.LastEnriched
-        description: The last Time DomainTools enriched domain data.
-        type: Date
-      - contextPath: DomainTools.Analytics.OverallRiskScore
-        description: The Overall Risk Score in DomainTools.
-        type: Number
-      - contextPath: DomainTools.Analytics.ProximityRiskScore
-        description: The Proximity Risk Score in DomainTools.
-        type: Number
-      - contextPath: DomainTools.Analytics.ThreatProfileRiskScore.RiskScore
-        description: The Threat Profile Risk Score in DomainTools.
-        type: Number
-      - contextPath: DomainTools.Analytics.ThreatProfileRiskScore.Threats
-        description: The threats of the Threat Profile Risk Score in DomainTools.
-        type: String
-      - contextPath: DomainTools.Analytics.ThreatProfileRiskScore.Evidence
-        description: The Threat Profile Risk Score Evidence in DomainTools.
-        type: String
-      - contextPath: DomainTools.Analytics.WebsiteResponseCode
-        description: The Website Response Code in DomainTools.
-        type: Number
-      - contextPath: DomainTools.Analytics.Tags
-        description: The Tags in DomainTools.
-        type: String
-      - contextPath: DomainTools.Identity.RegistrantName
-        description: The name of the registrant.
-        type: String
-      - contextPath: DomainTools.Identity.RegistrantOrg
-        description: The organization of the registrant.
-        type: String
-      - contextPath: DomainTools.Identity.RegistrantContact.Country.value
-        description: The country value of the registrant contact.
-        type: String
-      - contextPath: DomainTools.Identity.RegistrantContact.Country.count
-        description: The count of the registrant contact country.
-        type: Number
-      - contextPath: DomainTools.Identity.RegistrantContact.Email.value
-        description: The Email value of the registrant contact.
-        type: String
-      - contextPath: DomainTools.Identity.RegistrantContact.Email.count
-        description: The Email count of the registrant contact.
-        type: Number
-      - contextPath: DomainTools.Identity.RegistrantContact.Name.value
-        description: The name value of the registrant contact.
-        type: String
-      - contextPath: DomainTools.Identity.RegistrantContact.Name.count
-        description: The name count of the registrant contact.
-        type: Number
-      - contextPath: DomainTools.Identity.RegistrantContact.Phone.value
-        description: The phone value of the registrant contact.
-        type: String
-      - contextPath: DomainTools.Identity.RegistrantContact.Phone.count
-        description: The phone count of the registrant contact.
-        type: Number
-      - contextPath: DomainTools.Identity.SOAEmail
-        description: The SOA record of the Email.
-        type: String
-      - contextPath: DomainTools.Identity.SSLCertificateEmail
-        description: The Email of the SSL certificate.
-        type: String
-      - contextPath: DomainTools.Identity.AdminContact.Country.value
-        description: The country value of the administrator contact.
-        type: String
-      - contextPath: DomainTools.Identity.AdminContact.Country.count
-        description: The country count of the administrator contact.
-        type: Number
-      - contextPath: DomainTools.Identity.AdminContact.Email.value
-        description: The Email value of the administrator contact.
-        type: String
-      - contextPath: DomainTools.Identity.AdminContact.Email.count
-        description: The Email count of the administrator contact.
-        type: Number
-      - contextPath: DomainTools.Identity.AdminContact.Name.value
-        description: The name value of the administrator contact.
-        type: String
-      - contextPath: DomainTools.Identity.AdminContact.Name.count
-        description: The name count of the administrator contact.
-        type: Number
-      - contextPath: DomainTools.Identity.AdminContact.Phone.value
-        description: The phone value of the administrator contact.
-        type: String
-      - contextPath: DomainTools.Identity.AdminContact.Phone.count
-        description: The phone count of the administrator contact.
-        type: Number
-      - contextPath: DomainTools.Identity.TechnicalContact.Country.value
-        description: The country value of the technical contact.
-        type: String
-      - contextPath: DomainTools.Identity.TechnicalContact.Country.count
-        description: The country count of the technical contact.
-        type: Number
-      - contextPath: DomainTools.Identity.TechnicalContact.Email.value
-        description: The Email value of the technical contact.
-        type: String
-      - contextPath: DomainTools.Identity.TechnicalContact.Email.count
-        description: The Email count of the technical contact.
-        type: Number
-      - contextPath: DomainTools.Identity.TechnicalContact.Name.value
-        description: The name value of the technical Contact.
-        type: String
-      - contextPath: DomainTools.Identity.TechnicalContact.Name.count
-        description: The name count of the technical contact.
-        type: Number
-      - contextPath: DomainTools.Identity.TechnicalContact.Phone.value
-        description: The phone value of the technical contact.
-        type: String
-      - contextPath: DomainTools.Identity.TechnicalContact.Phone.count
-        description: The phone count of the technical contact.
-        type: Number
-      - contextPath: DomainTools.Identity.BillingContact.Country.value
-        description: The country value of the billing contact.
-        type: String
-      - contextPath: DomainTools.Identity.BillingContact.Country.count
-        description: The country count of the billing contact.
-        type: Number
-      - contextPath: DomainTools.Identity.BillingContact.Email.value
-        description: The Email value of the billing contact.
-        type: String
-      - contextPath: DomainTools.Identity.BillingContact.Email.count
-        description: The Email count of the billing contact.
-        type: Number
-      - contextPath: DomainTools.Identity.BillingContact.Name.value
-        description: The name value of the billing contact.
-        type: String
-      - contextPath: DomainTools.Identity.BillingContact.Name.count
-        description: The name count of the billing contact.
-        type: Number
-      - contextPath: DomainTools.Identity.BillingContact.Phone.value
-        description: The phone value of the billing contact.
-        type: String
-      - contextPath: DomainTools.Identity.BillingContact.Phone.count
-        description: The phone count of the billing contact.
-        type: Number
-      - contextPath: DomainTools.Identity.EmailDomains
-        description: The Email Domains.
-        type: String
-      - contextPath: DomainTools.Identity.AdditionalWhoisEmails.value
-        description: The value of the Additional Whois Emails record.
-        type: String
-      - contextPath: DomainTools.Identity.AdditionalWhoisEmails.count
-        description: The count of the Additional Whois Emails record.
-        type: Number
-      - contextPath: DomainTools.Registration.DomainRegistrant
-        description: The registrant of the domain.
-        type: String
-      - contextPath: DomainTools.Registration.RegistrarStatus
-        description: The status of the registrar.
-        type: String
-      - contextPath: DomainTools.Registration.DomainStatus
-        description: The active status of the domain.
-        type: Boolean
-      - contextPath: DomainTools.Registration.CreateDate
-        description: The date the domain was created.
-        type: Date
-      - contextPath: DomainTools.Registration.ExpirationDate
-        description: The expiration date of the domain.
-        type: Date
-      - contextPath: DomainTools.Hosting.IPAddresses.address.value
-        description: The address value of IP addresses.
-        type: String
-      - contextPath: DomainTools.Hosting.IPAddresses.address.count
-        description: The address count of IP addresses.
-        type: Number
-      - contextPath: DomainTools.Hosting.IPAddresses.asn.value
-        description: The ASN value of IP addresses.
-        type: String
-      - contextPath: DomainTools.Hosting.IPAddresses.asn.count
-        description: The ASN count of IP addresses.
-        type: Number
-      - contextPath: DomainTools.Hosting.IPAddresses.country_code.value
-        description: The country code value of IP addresses.
-        type: String
-      - contextPath: DomainTools.Hosting.IPAddresses.country_code.count
-        description: The country code count of IP addresses.
-        type: Number
-      - contextPath: DomainTools.Hosting.IPAddresses.isp.value
-        description: The ISP value of IP addresses.
-        type: String
-      - contextPath: DomainTools.Hosting.IPAddresses.isp.count
-        description: The ISP count of IP addresses.
-        type: Number
-      - contextPath: DomainTools.Hosting.IPCountryCode
-        description: The country code of the IP address.
-        type: String
-      - contextPath: DomainTools.Hosting.MailServers.domain.value
-        description: The domain value of the Mail Servers.
-        type: String
-      - contextPath: DomainTools.Hosting.MailServers.domain.count
-        description: The domain count of the Mail Servers.
-        type: Number
-      - contextPath: DomainTools.Hosting.MailServers.host.value
-        description: The host value of the Mail Servers.
-        type: String
-      - contextPath: DomainTools.Hosting.MailServers.host.count
-        description: The host count of the Mail Servers.
-        type: Number
-      - contextPath: DomainTools.Hosting.MailServers.ip.value
-        description: The IP value of the Mail Servers.
-        type: String
-      - contextPath: DomainTools.Hosting.MailServers.ip.count
-        description: The IP count of the Mail Servers.
-        type: Number
-      - contextPath: DomainTools.Hosting.SPFRecord
-        description: The SPF Record.
-        type: String
-      - contextPath: DomainTools.Hosting.NameServers.domain.value
-        description: The domain value of the domain NameServers.
-        type: String
-      - contextPath: DomainTools.Hosting.NameServers.domain.count
-        description: The domain count of the domain NameServers.
-        type: Number
-      - contextPath: DomainTools.Hosting.NameServers.host.value
-        description: The host value of the domain NameServers.
-        type: String
-      - contextPath: DomainTools.Hosting.NameServers.host.count
-        description: The host count of the domain NameServers.
-        type: Number
-      - contextPath: DomainTools.Hosting.NameServers.ip.value
-        description: The IP value of the domain NameServers.
-        type: String
-      - contextPath: DomainTools.Hosting.NameServers.ip.count
-        description: The IP count of domain NameServers.
-        type: Number
-      - contextPath: DomainTools.Hosting.SSLCertificate.hash.value
-        description: The hash value of the SSL certificate.
-        type: String
-      - contextPath: DomainTools.Hosting.SSLCertificate.hash.count
-        description: The hash count of the SSL certificate.
-        type: Number
-      - contextPath: DomainTools.Hosting.SSLCertificate.organization.value
-        description: The organization value of the SSL certificate.
-        type: String
-      - contextPath: DomainTools.Hosting.SSLCertificate.organization.count
-        description: The organization count of the SSL certificate information.
-        type: Number
-      - contextPath: DomainTools.Hosting.SSLCertificate.subject.value
-        description: The subject value of the SSL certificate information.
-        type: String
-      - contextPath: DomainTools.Hosting.SSLCertificate.subject.count
-        description: The subject count of the SSL certificate information.
-        type: Number
-      - contextPath: DomainTools.Hosting.RedirectsTo.value
-        description: The Redirects To Value of the domain.
-        type: String
-      - contextPath: DomainTools.Hosting.RedirectsTo.count
-        description: The Redirects To Count of the domain.
-        type: Number
-      - contextPath: DomainTools.Analytics.GoogleAdsenseTrackingCode
-        description: The tracking code of Google Adsense.
-        type: Number
-      - contextPath: DomainTools.Analytics.GoogleAnalyticTrackingCode
-        description: The tracking code of Google Analytics.
-        type: Number
-      - contextPath: DomainTools.Domains.Analytics.GA4TrackingCode
-        description: The tracking code of ga4.
-        type: Number
-      - contextPath: DomainTools.Domains.Analytics.GTMTrackingCode
-        description: The tracking code of gtm.
-        type: Number
-      - contextPath: DomainTools.Domains.Analytics.FBTrackingCode
-        description: The tracking code of fb.
-        type: Number
-      - contextPath: DomainTools.Domains.Analytics.HotJarTrackingCode
-        description: The tracking code of Hot Jar.
-        type: Number
-      - contextPath: DomainTools.Domains.Analytics.BaiduTrackingCode
-        description: The tracking code of Baidu.
-        type: Number
-      - contextPath: DomainTools.Domains.Analytics.YandexTrackingCode
-        description: The tracking code of Yandex.
-        type: Number
-      - contextPath: DomainTools.Domains.Analytics.MatomoTrackingCode
-        description: The tracking code of Matomo.
-        type: Number
-      - contextPath: DomainTools.Domains.Analytics.StatcounterProjectTrackingCode
-        description: The tracking code of Stat Counter Project.
-        type: Number
-      - contextPath: DomainTools.Domains.Analytics.StatcounterSecurityTrackingCode
-        description: The tracking code of Stat Counter Security.
-        type: Number
-      - contextPath: DomainTools.WebsiteTitle
-        description: The website title.
-        type: Number
-      - contextPath: DomainTools.FirstSeen
-        description: The date the domain was first seen.
-        type: Number
-      - contextPath: DomainTools.ServerType
-        description: The server type.
-        type: Number
-      - contextPath: DBotScore.Indicator
-        description: The indicator of the DBotScore.
-        type: String
-      - contextPath: DBotScore.Type
-        description: The indicator type of the DBotScore.
-        type: String
-      - contextPath: DBotScore.Vendor
-        description: The vendor used to calculate the score.
-        type: String
-      - contextPath: DBotScore.Score
-        description: The actual score.
-        type: Number
+    - contextPath: Domain.Name
+      description: The name of the domain.
+      type: String
+    - contextPath: Domain.DNS
+      description: The DNS of the domain.
+      type: String
+    - contextPath: Domain.DomainStatus
+      description: The status of the domain.
+      type: Boolean
+    - contextPath: Domain.CreationDate
+      description: The creation date.
+      type: Date
+    - contextPath: Domain.ExpirationDate
+      description: The expiration date of the domain.
+      type: Date
+    - contextPath: Domain.NameServers
+      description: The nameServers of the domain.
+      type: String
+    - contextPath: Domain.Registrant.Country
+      description: The registrant country of the domain.
+      type: String
+    - contextPath: Domain.Registrant.Email
+      description: The registrant email of the domain.
+      type: String
+    - contextPath: Domain.Registrant.Name
+      description: The registrant name of the domain.
+      type: String
+    - contextPath: Domain.Registrant.Phone
+      description: The registrant phone number of the domain.
+      type: String
+    - contextPath: Domain.Malicious.Vendor
+      description: The vendor who classified the domain as malicious.
+      type: String
+    - contextPath: Domain.Malicious.Description
+      description: The description as to why the domain was found to be malicious.
+      type: String
+    - contextPath: DomainTools.Name
+      description: The domain name in DomainTools.
+      type: String
+    - contextPath: DomainTools.LastEnriched
+      description: The last Time DomainTools enriched domain data.
+      type: Date
+    - contextPath: DomainTools.Analytics.OverallRiskScore
+      description: The Overall Risk Score in DomainTools.
+      type: Number
+    - contextPath: DomainTools.Analytics.ProximityRiskScore
+      description: The Proximity Risk Score in DomainTools.
+      type: Number
+    - contextPath: DomainTools.Analytics.ThreatProfileRiskScore.RiskScore
+      description: The Threat Profile Risk Score in DomainTools.
+      type: Number
+    - contextPath: DomainTools.Analytics.ThreatProfileRiskScore.Threats
+      description: The threats of the Threat Profile Risk Score in DomainTools.
+      type: String
+    - contextPath: DomainTools.Analytics.ThreatProfileRiskScore.Evidence
+      description: The Threat Profile Risk Score Evidence in DomainTools.
+      type: String
+    - contextPath: DomainTools.Analytics.WebsiteResponseCode
+      description: The Website Response Code in DomainTools.
+      type: Number
+    - contextPath: DomainTools.Analytics.Tags
+      description: The Tags in DomainTools.
+      type: String
+    - contextPath: DomainTools.Identity.RegistrantName
+      description: The name of the registrant.
+      type: String
+    - contextPath: DomainTools.Identity.RegistrantOrg
+      description: The organization of the registrant.
+      type: String
+    - contextPath: DomainTools.Identity.RegistrantContact.Country.value
+      description: The country value of the registrant contact.
+      type: String
+    - contextPath: DomainTools.Identity.RegistrantContact.Country.count
+      description: The count of the registrant contact country.
+      type: Number
+    - contextPath: DomainTools.Identity.RegistrantContact.Email.value
+      description: The Email value of the registrant contact.
+      type: String
+    - contextPath: DomainTools.Identity.RegistrantContact.Email.count
+      description: The Email count of the registrant contact.
+      type: Number
+    - contextPath: DomainTools.Identity.RegistrantContact.Name.value
+      description: The name value of the registrant contact.
+      type: String
+    - contextPath: DomainTools.Identity.RegistrantContact.Name.count
+      description: The name count of the registrant contact.
+      type: Number
+    - contextPath: DomainTools.Identity.RegistrantContact.Phone.value
+      description: The phone value of the registrant contact.
+      type: String
+    - contextPath: DomainTools.Identity.RegistrantContact.Phone.count
+      description: The phone count of the registrant contact.
+      type: Number
+    - contextPath: DomainTools.Identity.SOAEmail
+      description: The SOA record of the Email.
+      type: String
+    - contextPath: DomainTools.Identity.SSLCertificateEmail
+      description: The Email of the SSL certificate.
+      type: String
+    - contextPath: DomainTools.Identity.AdminContact.Country.value
+      description: The country value of the administrator contact.
+      type: String
+    - contextPath: DomainTools.Identity.AdminContact.Country.count
+      description: The country count of the administrator contact.
+      type: Number
+    - contextPath: DomainTools.Identity.AdminContact.Email.value
+      description: The Email value of the administrator contact.
+      type: String
+    - contextPath: DomainTools.Identity.AdminContact.Email.count
+      description: The Email count of the administrator contact.
+      type: Number
+    - contextPath: DomainTools.Identity.AdminContact.Name.value
+      description: The name value of the administrator contact.
+      type: String
+    - contextPath: DomainTools.Identity.AdminContact.Name.count
+      description: The name count of the administrator contact.
+      type: Number
+    - contextPath: DomainTools.Identity.AdminContact.Phone.value
+      description: The phone value of the administrator contact.
+      type: String
+    - contextPath: DomainTools.Identity.AdminContact.Phone.count
+      description: The phone count of the administrator contact.
+      type: Number
+    - contextPath: DomainTools.Identity.TechnicalContact.Country.value
+      description: The country value of the technical contact.
+      type: String
+    - contextPath: DomainTools.Identity.TechnicalContact.Country.count
+      description: The country count of the technical contact.
+      type: Number
+    - contextPath: DomainTools.Identity.TechnicalContact.Email.value
+      description: The Email value of the technical contact.
+      type: String
+    - contextPath: DomainTools.Identity.TechnicalContact.Email.count
+      description: The Email count of the technical contact.
+      type: Number
+    - contextPath: DomainTools.Identity.TechnicalContact.Name.value
+      description: The name value of the technical Contact.
+      type: String
+    - contextPath: DomainTools.Identity.TechnicalContact.Name.count
+      description: The name count of the technical contact.
+      type: Number
+    - contextPath: DomainTools.Identity.TechnicalContact.Phone.value
+      description: The phone value of the technical contact.
+      type: String
+    - contextPath: DomainTools.Identity.TechnicalContact.Phone.count
+      description: The phone count of the technical contact.
+      type: Number
+    - contextPath: DomainTools.Identity.BillingContact.Country.value
+      description: The country value of the billing contact.
+      type: String
+    - contextPath: DomainTools.Identity.BillingContact.Country.count
+      description: The country count of the billing contact.
+      type: Number
+    - contextPath: DomainTools.Identity.BillingContact.Email.value
+      description: The Email value of the billing contact.
+      type: String
+    - contextPath: DomainTools.Identity.BillingContact.Email.count
+      description: The Email count of the billing contact.
+      type: Number
+    - contextPath: DomainTools.Identity.BillingContact.Name.value
+      description: The name value of the billing contact.
+      type: String
+    - contextPath: DomainTools.Identity.BillingContact.Name.count
+      description: The name count of the billing contact.
+      type: Number
+    - contextPath: DomainTools.Identity.BillingContact.Phone.value
+      description: The phone value of the billing contact.
+      type: String
+    - contextPath: DomainTools.Identity.BillingContact.Phone.count
+      description: The phone count of the billing contact.
+      type: Number
+    - contextPath: DomainTools.Identity.EmailDomains
+      description: The Email Domains.
+      type: String
+    - contextPath: DomainTools.Identity.AdditionalWhoisEmails.value
+      description: The value of the Additional Whois Emails record.
+      type: String
+    - contextPath: DomainTools.Identity.AdditionalWhoisEmails.count
+      description: The count of the Additional Whois Emails record.
+      type: Number
+    - contextPath: DomainTools.Registration.DomainRegistrant
+      description: The registrant of the domain.
+      type: String
+    - contextPath: DomainTools.Registration.RegistrarStatus
+      description: The status of the registrar.
+      type: String
+    - contextPath: DomainTools.Registration.DomainStatus
+      description: The active status of the domain.
+      type: Boolean
+    - contextPath: DomainTools.Registration.CreateDate
+      description: The date the domain was created.
+      type: Date
+    - contextPath: DomainTools.Registration.ExpirationDate
+      description: The expiration date of the domain.
+      type: Date
+    - contextPath: DomainTools.Hosting.IPAddresses.address.value
+      description: The address value of IP addresses.
+      type: String
+    - contextPath: DomainTools.Hosting.IPAddresses.address.count
+      description: The address count of IP addresses.
+      type: Number
+    - contextPath: DomainTools.Hosting.IPAddresses.asn.value
+      description: The ASN value of IP addresses.
+      type: String
+    - contextPath: DomainTools.Hosting.IPAddresses.asn.count
+      description: The ASN count of IP addresses.
+      type: Number
+    - contextPath: DomainTools.Hosting.IPAddresses.country_code.value
+      description: The country code value of IP addresses.
+      type: String
+    - contextPath: DomainTools.Hosting.IPAddresses.country_code.count
+      description: The country code count of IP addresses.
+      type: Number
+    - contextPath: DomainTools.Hosting.IPAddresses.isp.value
+      description: The ISP value of IP addresses.
+      type: String
+    - contextPath: DomainTools.Hosting.IPAddresses.isp.count
+      description: The ISP count of IP addresses.
+      type: Number
+    - contextPath: DomainTools.Hosting.IPCountryCode
+      description: The country code of the IP address.
+      type: String
+    - contextPath: DomainTools.Hosting.MailServers.domain.value
+      description: The domain value of the Mail Servers.
+      type: String
+    - contextPath: DomainTools.Hosting.MailServers.domain.count
+      description: The domain count of the Mail Servers.
+      type: Number
+    - contextPath: DomainTools.Hosting.MailServers.host.value
+      description: The host value of the Mail Servers.
+      type: String
+    - contextPath: DomainTools.Hosting.MailServers.host.count
+      description: The host count of the Mail Servers.
+      type: Number
+    - contextPath: DomainTools.Hosting.MailServers.ip.value
+      description: The IP value of the Mail Servers.
+      type: String
+    - contextPath: DomainTools.Hosting.MailServers.ip.count
+      description: The IP count of the Mail Servers.
+      type: Number
+    - contextPath: DomainTools.Hosting.SPFRecord
+      description: The SPF Record.
+      type: String
+    - contextPath: DomainTools.Hosting.NameServers.domain.value
+      description: The domain value of the domain NameServers.
+      type: String
+    - contextPath: DomainTools.Hosting.NameServers.domain.count
+      description: The domain count of the domain NameServers.
+      type: Number
+    - contextPath: DomainTools.Hosting.NameServers.host.value
+      description: The host value of the domain NameServers.
+      type: String
+    - contextPath: DomainTools.Hosting.NameServers.host.count
+      description: The host count of the domain NameServers.
+      type: Number
+    - contextPath: DomainTools.Hosting.NameServers.ip.value
+      description: The IP value of the domain NameServers.
+      type: String
+    - contextPath: DomainTools.Hosting.NameServers.ip.count
+      description: The IP count of domain NameServers.
+      type: Number
+    - contextPath: DomainTools.Hosting.SSLCertificate.hash.value
+      description: The hash value of the SSL certificate.
+      type: String
+    - contextPath: DomainTools.Hosting.SSLCertificate.hash.count
+      description: The hash count of the SSL certificate.
+      type: Number
+    - contextPath: DomainTools.Hosting.SSLCertificate.organization.value
+      description: The organization value of the SSL certificate.
+      type: String
+    - contextPath: DomainTools.Hosting.SSLCertificate.organization.count
+      description: The organization count of the SSL certificate information.
+      type: Number
+    - contextPath: DomainTools.Hosting.SSLCertificate.subject.value
+      description: The subject value of the SSL certificate information.
+      type: String
+    - contextPath: DomainTools.Hosting.SSLCertificate.subject.count
+      description: The subject count of the SSL certificate information.
+      type: Number
+    - contextPath: DomainTools.Hosting.RedirectsTo.value
+      description: The Redirects To Value of the domain.
+      type: String
+    - contextPath: DomainTools.Hosting.RedirectsTo.count
+      description: The Redirects To Count of the domain.
+      type: Number
+    - contextPath: DomainTools.Analytics.GoogleAdsenseTrackingCode
+      description: The tracking code of Google Adsense.
+      type: Number
+    - contextPath: DomainTools.Analytics.GoogleAnalyticTrackingCode
+      description: The tracking code of Google Analytics.
+      type: Number
+    - contextPath: DomainTools.Domains.Analytics.GA4TrackingCode
+      description: The tracking code of ga4.
+      type: Number
+    - contextPath: DomainTools.Domains.Analytics.GTMTrackingCode
+      description: The tracking code of gtm.
+      type: Number
+    - contextPath: DomainTools.Domains.Analytics.FBTrackingCode
+      description: The tracking code of fb.
+      type: Number
+    - contextPath: DomainTools.Domains.Analytics.HotJarTrackingCode
+      description: The tracking code of Hot Jar.
+      type: Number
+    - contextPath: DomainTools.Domains.Analytics.BaiduTrackingCode
+      description: The tracking code of Baidu.
+      type: Number
+    - contextPath: DomainTools.Domains.Analytics.YandexTrackingCode
+      description: The tracking code of Yandex.
+      type: Number
+    - contextPath: DomainTools.Domains.Analytics.MatomoTrackingCode
+      description: The tracking code of Matomo.
+      type: Number
+    - contextPath: DomainTools.Domains.Analytics.StatcounterProjectTrackingCode
+      description: The tracking code of Stat Counter Project.
+      type: Number
+    - contextPath: DomainTools.Domains.Analytics.StatcounterSecurityTrackingCode
+      description: The tracking code of Stat Counter Security.
+      type: Number
+    - contextPath: DomainTools.WebsiteTitle
+      description: The website title.
+      type: Number
+    - contextPath: DomainTools.FirstSeen
+      description: The date the domain was first seen.
+      type: Number
+    - contextPath: DomainTools.ServerType
+      description: The server type.
+      type: Number
+    - contextPath: DBotScore.Indicator
+      description: The indicator of the DBotScore.
+      type: String
+    - contextPath: DBotScore.Type
+      description: The indicator type of the DBotScore.
+      type: String
+    - contextPath: DBotScore.Vendor
+      description: The vendor used to calculate the score.
+      type: String
+    - contextPath: DBotScore.Score
+      description: The actual score.
+      type: Number
     deprecated: false
     execution: false
   - arguments:
@@ -1197,16 +1197,16 @@ script:
     deprecated: false
     execution: false
   - arguments:
-    - description: The domain name to display.
+    - default: false
+      description: The domain name to display.
       name: domain
       required: true
-      default: false
       isArray: false
       secret: false
-    - default: true
-      description: Include the enrich results in Context Data. Defaults to true.
-      isArray: false
+    - description: Include the enrich results in Context Data. Defaults to true.
       name: include_context
+      default: true
+      isArray: false
       required: false
       secret: false
       type: String
@@ -2409,7 +2409,7 @@ script:
       description: Parsed Whois data.
     - contextPath: Domain.WhoisRecords
       description: Full Whois record.
-  dockerimage: demisto/vendors-sdk:1.0.0.82771
+  dockerimage: demisto/vendors-sdk:1.0.0.83426
   runonce: false
   script: '-'
   type: python

--- a/Packs/DomainTools_Iris/Integrations/DomainTools_Iris/DomainTools_Iris.yml
+++ b/Packs/DomainTools_Iris/Integrations/DomainTools_Iris/DomainTools_Iris.yml
@@ -121,24 +121,12 @@ script:
   commands:
   - arguments:
     - default: true
-      description: The domain name (SLD.TLD) to Investigate. Supports up to 1,000 comma-separated domains.
+      description: The domain to enrich.
       name: domain
       required: true
       isArray: false
       secret: false
-    - default: false
-      description: Include the investigate results in Context Data. Defaults to true.
-      isArray: false
-      name: include_context
-      required: false
-      secret: false
-      type: String
-      predefined:
-      - "true"
-      - "false"
-      auto: PREDEFINED
-      defaultValue: "true"
-    description: Returns a complete profile of the domain (SLD.TLD) using Iris Investigate. If parsing of FQDNs is desired, see domainExtractAndInvestigate.
+    description: Provides data enrichment for domains.
     name: domain
     outputs:
     - contextPath: Domain.Name
@@ -480,6 +468,369 @@ script:
     - contextPath: DBotScore.Score
       description: The actual score.
       type: Number
+    deprecated: false
+    execution: false
+  - arguments:
+      - default: true
+        description: The domain name (SLD.TLD) to Investigate. Supports up to 1,000 comma-separated domains.
+        name: domain
+        required: true
+        isArray: false
+        secret: false
+      - default: false
+        description: Include the investigate results in Context Data. Defaults to true.
+        isArray: false
+        name: include_context
+        required: false
+        secret: false
+        type: String
+        predefined:
+          - "true"
+          - "false"
+        auto: PREDEFINED
+        defaultValue: "true"
+    description: Returns a complete profile of the domain (SLD.TLD) using Iris Investigate. If parsing of FQDNs is desired, see domainExtractAndInvestigate.
+    name: domaintoolsiris-investigate
+    outputs:
+      - contextPath: Domain.Name
+        description: The name of the domain.
+        type: String
+      - contextPath: Domain.DNS
+        description: The DNS of the domain.
+        type: String
+      - contextPath: Domain.DomainStatus
+        description: The status of the domain.
+        type: Boolean
+      - contextPath: Domain.CreationDate
+        description: The creation date.
+        type: Date
+      - contextPath: Domain.ExpirationDate
+        description: The expiration date of the domain.
+        type: Date
+      - contextPath: Domain.NameServers
+        description: The nameServers of the domain.
+        type: String
+      - contextPath: Domain.Registrant.Country
+        description: The registrant country of the domain.
+        type: String
+      - contextPath: Domain.Registrant.Email
+        description: The registrant email of the domain.
+        type: String
+      - contextPath: Domain.Registrant.Name
+        description: The registrant name of the domain.
+        type: String
+      - contextPath: Domain.Registrant.Phone
+        description: The registrant phone number of the domain.
+        type: String
+      - contextPath: Domain.Malicious.Vendor
+        description: The vendor who classified the domain as malicious.
+        type: String
+      - contextPath: Domain.Malicious.Description
+        description: The description as to why the domain was found to be malicious.
+        type: String
+      - contextPath: DomainTools.Name
+        description: The domain name in DomainTools.
+        type: String
+      - contextPath: DomainTools.LastEnriched
+        description: The last Time DomainTools enriched domain data.
+        type: Date
+      - contextPath: DomainTools.Analytics.OverallRiskScore
+        description: The Overall Risk Score in DomainTools.
+        type: Number
+      - contextPath: DomainTools.Analytics.ProximityRiskScore
+        description: The Proximity Risk Score in DomainTools.
+        type: Number
+      - contextPath: DomainTools.Analytics.ThreatProfileRiskScore.RiskScore
+        description: The Threat Profile Risk Score in DomainTools.
+        type: Number
+      - contextPath: DomainTools.Analytics.ThreatProfileRiskScore.Threats
+        description: The threats of the Threat Profile Risk Score in DomainTools.
+        type: String
+      - contextPath: DomainTools.Analytics.ThreatProfileRiskScore.Evidence
+        description: The Threat Profile Risk Score Evidence in DomainTools.
+        type: String
+      - contextPath: DomainTools.Analytics.WebsiteResponseCode
+        description: The Website Response Code in DomainTools.
+        type: Number
+      - contextPath: DomainTools.Analytics.Tags
+        description: The Tags in DomainTools.
+        type: String
+      - contextPath: DomainTools.Identity.RegistrantName
+        description: The name of the registrant.
+        type: String
+      - contextPath: DomainTools.Identity.RegistrantOrg
+        description: The organization of the registrant.
+        type: String
+      - contextPath: DomainTools.Identity.RegistrantContact.Country.value
+        description: The country value of the registrant contact.
+        type: String
+      - contextPath: DomainTools.Identity.RegistrantContact.Country.count
+        description: The count of the registrant contact country.
+        type: Number
+      - contextPath: DomainTools.Identity.RegistrantContact.Email.value
+        description: The Email value of the registrant contact.
+        type: String
+      - contextPath: DomainTools.Identity.RegistrantContact.Email.count
+        description: The Email count of the registrant contact.
+        type: Number
+      - contextPath: DomainTools.Identity.RegistrantContact.Name.value
+        description: The name value of the registrant contact.
+        type: String
+      - contextPath: DomainTools.Identity.RegistrantContact.Name.count
+        description: The name count of the registrant contact.
+        type: Number
+      - contextPath: DomainTools.Identity.RegistrantContact.Phone.value
+        description: The phone value of the registrant contact.
+        type: String
+      - contextPath: DomainTools.Identity.RegistrantContact.Phone.count
+        description: The phone count of the registrant contact.
+        type: Number
+      - contextPath: DomainTools.Identity.SOAEmail
+        description: The SOA record of the Email.
+        type: String
+      - contextPath: DomainTools.Identity.SSLCertificateEmail
+        description: The Email of the SSL certificate.
+        type: String
+      - contextPath: DomainTools.Identity.AdminContact.Country.value
+        description: The country value of the administrator contact.
+        type: String
+      - contextPath: DomainTools.Identity.AdminContact.Country.count
+        description: The country count of the administrator contact.
+        type: Number
+      - contextPath: DomainTools.Identity.AdminContact.Email.value
+        description: The Email value of the administrator contact.
+        type: String
+      - contextPath: DomainTools.Identity.AdminContact.Email.count
+        description: The Email count of the administrator contact.
+        type: Number
+      - contextPath: DomainTools.Identity.AdminContact.Name.value
+        description: The name value of the administrator contact.
+        type: String
+      - contextPath: DomainTools.Identity.AdminContact.Name.count
+        description: The name count of the administrator contact.
+        type: Number
+      - contextPath: DomainTools.Identity.AdminContact.Phone.value
+        description: The phone value of the administrator contact.
+        type: String
+      - contextPath: DomainTools.Identity.AdminContact.Phone.count
+        description: The phone count of the administrator contact.
+        type: Number
+      - contextPath: DomainTools.Identity.TechnicalContact.Country.value
+        description: The country value of the technical contact.
+        type: String
+      - contextPath: DomainTools.Identity.TechnicalContact.Country.count
+        description: The country count of the technical contact.
+        type: Number
+      - contextPath: DomainTools.Identity.TechnicalContact.Email.value
+        description: The Email value of the technical contact.
+        type: String
+      - contextPath: DomainTools.Identity.TechnicalContact.Email.count
+        description: The Email count of the technical contact.
+        type: Number
+      - contextPath: DomainTools.Identity.TechnicalContact.Name.value
+        description: The name value of the technical Contact.
+        type: String
+      - contextPath: DomainTools.Identity.TechnicalContact.Name.count
+        description: The name count of the technical contact.
+        type: Number
+      - contextPath: DomainTools.Identity.TechnicalContact.Phone.value
+        description: The phone value of the technical contact.
+        type: String
+      - contextPath: DomainTools.Identity.TechnicalContact.Phone.count
+        description: The phone count of the technical contact.
+        type: Number
+      - contextPath: DomainTools.Identity.BillingContact.Country.value
+        description: The country value of the billing contact.
+        type: String
+      - contextPath: DomainTools.Identity.BillingContact.Country.count
+        description: The country count of the billing contact.
+        type: Number
+      - contextPath: DomainTools.Identity.BillingContact.Email.value
+        description: The Email value of the billing contact.
+        type: String
+      - contextPath: DomainTools.Identity.BillingContact.Email.count
+        description: The Email count of the billing contact.
+        type: Number
+      - contextPath: DomainTools.Identity.BillingContact.Name.value
+        description: The name value of the billing contact.
+        type: String
+      - contextPath: DomainTools.Identity.BillingContact.Name.count
+        description: The name count of the billing contact.
+        type: Number
+      - contextPath: DomainTools.Identity.BillingContact.Phone.value
+        description: The phone value of the billing contact.
+        type: String
+      - contextPath: DomainTools.Identity.BillingContact.Phone.count
+        description: The phone count of the billing contact.
+        type: Number
+      - contextPath: DomainTools.Identity.EmailDomains
+        description: The Email Domains.
+        type: String
+      - contextPath: DomainTools.Identity.AdditionalWhoisEmails.value
+        description: The value of the Additional Whois Emails record.
+        type: String
+      - contextPath: DomainTools.Identity.AdditionalWhoisEmails.count
+        description: The count of the Additional Whois Emails record.
+        type: Number
+      - contextPath: DomainTools.Registration.DomainRegistrant
+        description: The registrant of the domain.
+        type: String
+      - contextPath: DomainTools.Registration.RegistrarStatus
+        description: The status of the registrar.
+        type: String
+      - contextPath: DomainTools.Registration.DomainStatus
+        description: The active status of the domain.
+        type: Boolean
+      - contextPath: DomainTools.Registration.CreateDate
+        description: The date the domain was created.
+        type: Date
+      - contextPath: DomainTools.Registration.ExpirationDate
+        description: The expiration date of the domain.
+        type: Date
+      - contextPath: DomainTools.Hosting.IPAddresses.address.value
+        description: The address value of IP addresses.
+        type: String
+      - contextPath: DomainTools.Hosting.IPAddresses.address.count
+        description: The address count of IP addresses.
+        type: Number
+      - contextPath: DomainTools.Hosting.IPAddresses.asn.value
+        description: The ASN value of IP addresses.
+        type: String
+      - contextPath: DomainTools.Hosting.IPAddresses.asn.count
+        description: The ASN count of IP addresses.
+        type: Number
+      - contextPath: DomainTools.Hosting.IPAddresses.country_code.value
+        description: The country code value of IP addresses.
+        type: String
+      - contextPath: DomainTools.Hosting.IPAddresses.country_code.count
+        description: The country code count of IP addresses.
+        type: Number
+      - contextPath: DomainTools.Hosting.IPAddresses.isp.value
+        description: The ISP value of IP addresses.
+        type: String
+      - contextPath: DomainTools.Hosting.IPAddresses.isp.count
+        description: The ISP count of IP addresses.
+        type: Number
+      - contextPath: DomainTools.Hosting.IPCountryCode
+        description: The country code of the IP address.
+        type: String
+      - contextPath: DomainTools.Hosting.MailServers.domain.value
+        description: The domain value of the Mail Servers.
+        type: String
+      - contextPath: DomainTools.Hosting.MailServers.domain.count
+        description: The domain count of the Mail Servers.
+        type: Number
+      - contextPath: DomainTools.Hosting.MailServers.host.value
+        description: The host value of the Mail Servers.
+        type: String
+      - contextPath: DomainTools.Hosting.MailServers.host.count
+        description: The host count of the Mail Servers.
+        type: Number
+      - contextPath: DomainTools.Hosting.MailServers.ip.value
+        description: The IP value of the Mail Servers.
+        type: String
+      - contextPath: DomainTools.Hosting.MailServers.ip.count
+        description: The IP count of the Mail Servers.
+        type: Number
+      - contextPath: DomainTools.Hosting.SPFRecord
+        description: The SPF Record.
+        type: String
+      - contextPath: DomainTools.Hosting.NameServers.domain.value
+        description: The domain value of the domain NameServers.
+        type: String
+      - contextPath: DomainTools.Hosting.NameServers.domain.count
+        description: The domain count of the domain NameServers.
+        type: Number
+      - contextPath: DomainTools.Hosting.NameServers.host.value
+        description: The host value of the domain NameServers.
+        type: String
+      - contextPath: DomainTools.Hosting.NameServers.host.count
+        description: The host count of the domain NameServers.
+        type: Number
+      - contextPath: DomainTools.Hosting.NameServers.ip.value
+        description: The IP value of the domain NameServers.
+        type: String
+      - contextPath: DomainTools.Hosting.NameServers.ip.count
+        description: The IP count of domain NameServers.
+        type: Number
+      - contextPath: DomainTools.Hosting.SSLCertificate.hash.value
+        description: The hash value of the SSL certificate.
+        type: String
+      - contextPath: DomainTools.Hosting.SSLCertificate.hash.count
+        description: The hash count of the SSL certificate.
+        type: Number
+      - contextPath: DomainTools.Hosting.SSLCertificate.organization.value
+        description: The organization value of the SSL certificate.
+        type: String
+      - contextPath: DomainTools.Hosting.SSLCertificate.organization.count
+        description: The organization count of the SSL certificate information.
+        type: Number
+      - contextPath: DomainTools.Hosting.SSLCertificate.subject.value
+        description: The subject value of the SSL certificate information.
+        type: String
+      - contextPath: DomainTools.Hosting.SSLCertificate.subject.count
+        description: The subject count of the SSL certificate information.
+        type: Number
+      - contextPath: DomainTools.Hosting.RedirectsTo.value
+        description: The Redirects To Value of the domain.
+        type: String
+      - contextPath: DomainTools.Hosting.RedirectsTo.count
+        description: The Redirects To Count of the domain.
+        type: Number
+      - contextPath: DomainTools.Analytics.GoogleAdsenseTrackingCode
+        description: The tracking code of Google Adsense.
+        type: Number
+      - contextPath: DomainTools.Analytics.GoogleAnalyticTrackingCode
+        description: The tracking code of Google Analytics.
+        type: Number
+      - contextPath: DomainTools.Domains.Analytics.GA4TrackingCode
+        description: The tracking code of ga4.
+        type: Number
+      - contextPath: DomainTools.Domains.Analytics.GTMTrackingCode
+        description: The tracking code of gtm.
+        type: Number
+      - contextPath: DomainTools.Domains.Analytics.FBTrackingCode
+        description: The tracking code of fb.
+        type: Number
+      - contextPath: DomainTools.Domains.Analytics.HotJarTrackingCode
+        description: The tracking code of Hot Jar.
+        type: Number
+      - contextPath: DomainTools.Domains.Analytics.BaiduTrackingCode
+        description: The tracking code of Baidu.
+        type: Number
+      - contextPath: DomainTools.Domains.Analytics.YandexTrackingCode
+        description: The tracking code of Yandex.
+        type: Number
+      - contextPath: DomainTools.Domains.Analytics.MatomoTrackingCode
+        description: The tracking code of Matomo.
+        type: Number
+      - contextPath: DomainTools.Domains.Analytics.StatcounterProjectTrackingCode
+        description: The tracking code of Stat Counter Project.
+        type: Number
+      - contextPath: DomainTools.Domains.Analytics.StatcounterSecurityTrackingCode
+        description: The tracking code of Stat Counter Security.
+        type: Number
+      - contextPath: DomainTools.WebsiteTitle
+        description: The website title.
+        type: Number
+      - contextPath: DomainTools.FirstSeen
+        description: The date the domain was first seen.
+        type: Number
+      - contextPath: DomainTools.ServerType
+        description: The server type.
+        type: Number
+      - contextPath: DBotScore.Indicator
+        description: The indicator of the DBotScore.
+        type: String
+      - contextPath: DBotScore.Type
+        description: The indicator type of the DBotScore.
+        type: String
+      - contextPath: DBotScore.Vendor
+        description: The vendor used to calculate the score.
+        type: String
+      - contextPath: DBotScore.Score
+        description: The actual score.
+        type: Number
     deprecated: false
     execution: false
   - arguments:

--- a/Packs/DomainTools_Iris/Integrations/DomainTools_Iris/README.md
+++ b/Packs/DomainTools_Iris/Integrations/DomainTools_Iris/README.md
@@ -1,6 +1,5 @@
-Together, DomainTools and Cortex XSOAR automate and orchestrate the incident response process with essential domain profile, web crawl, SSL and infrastructure data. SOCs can create custom, automated workflows to trigger Indicator of Compromise (IoC) investigations, block threats based on connected infrastructure, and identify potentially malicious domains before weaponization.
-The DomainTools App for Cortex XSOAR is shipped with pre-built playbooks to enable automated enrichment, decision logic, ad-hoc investigations, and the ability to persist enriched intelligence.
-This integration was integrated and tested with version 1.0 of DomainTools Iris
+Together, DomainTools and Cortex XSOAR automate and orchestrate the incident response process with essential domain profile, web crawl, SSL and infrastructure data. SOCs can create custom, automated workflows to trigger Indicator of Compromise (IoC) investigations, block threats based on connected infrastructure, and identify potentially malicious domains before weaponization. The DomainTools App for Cortex XSOAR is shipped with pre-built playbooks to enable automated enrichment, decision logic, ad-hoc investigations, and the ability to persist enriched intelligence.
+This integration was integrated and tested with version 1.0 of DomainTools Iris.
 
 ## Configure DomainTools Iris on Cortex XSOAR
 
@@ -40,11 +39,144 @@ After you successfully execute a command, a DBot message appears in the War Room
 ### domain
 
 ***
-Returns a complete profile of the domain (SLD.TLD) using Iris Investigate. If parsing of FQDNs is desired, see domainExtractAndInvestigate.
+Provides data enrichment for domains.
 
 #### Base Command
 
 `domain`
+
+#### Input
+
+| **Argument Name** | **Description** | **Required** |
+| --- | --- | --- |
+| domain | The domain to enrich. | Required | 
+
+#### Context Output
+
+| **Path** | **Type** | **Description** |
+| --- | --- | --- |
+| Domain.Name | String | The name of the domain. | 
+| Domain.DNS | String | The DNS of the domain. | 
+| Domain.DomainStatus | Boolean | The status of the domain. | 
+| Domain.CreationDate | Date | The creation date. | 
+| Domain.ExpirationDate | Date | The expiration date of the domain. | 
+| Domain.NameServers | String | The nameServers of the domain. | 
+| Domain.Registrant.Country | String | The registrant country of the domain. | 
+| Domain.Registrant.Email | String | The registrant email of the domain. | 
+| Domain.Registrant.Name | String | The registrant name of the domain. | 
+| Domain.Registrant.Phone | String | The registrant phone number of the domain. | 
+| Domain.Malicious.Vendor | String | The vendor who classified the domain as malicious. | 
+| Domain.Malicious.Description | String | The description as to why the domain was found to be malicious. | 
+| DomainTools.Name | String | The domain name in DomainTools. | 
+| DomainTools.LastEnriched | Date | The last Time DomainTools enriched domain data. | 
+| DomainTools.Analytics.OverallRiskScore | Number | The Overall Risk Score in DomainTools. | 
+| DomainTools.Analytics.ProximityRiskScore | Number | The Proximity Risk Score in DomainTools. | 
+| DomainTools.Analytics.ThreatProfileRiskScore.RiskScore | Number | The Threat Profile Risk Score in DomainTools. | 
+| DomainTools.Analytics.ThreatProfileRiskScore.Threats | String | The threats of the Threat Profile Risk Score in DomainTools. | 
+| DomainTools.Analytics.ThreatProfileRiskScore.Evidence | String | The Threat Profile Risk Score Evidence in DomainTools. | 
+| DomainTools.Analytics.WebsiteResponseCode | Number | The Website Response Code in DomainTools. | 
+| DomainTools.Analytics.Tags | String | The Tags in DomainTools. | 
+| DomainTools.Identity.RegistrantName | String | The name of the registrant. | 
+| DomainTools.Identity.RegistrantOrg | String | The organization of the registrant. | 
+| DomainTools.Identity.RegistrantContact.Country.value | String | The country value of the registrant contact. | 
+| DomainTools.Identity.RegistrantContact.Country.count | Number | The count of the registrant contact country. | 
+| DomainTools.Identity.RegistrantContact.Email.value | String | The Email value of the registrant contact. | 
+| DomainTools.Identity.RegistrantContact.Email.count | Number | The Email count of the registrant contact. | 
+| DomainTools.Identity.RegistrantContact.Name.value | String | The name value of the registrant contact. | 
+| DomainTools.Identity.RegistrantContact.Name.count | Number | The name count of the registrant contact. | 
+| DomainTools.Identity.RegistrantContact.Phone.value | String | The phone value of the registrant contact. | 
+| DomainTools.Identity.RegistrantContact.Phone.count | Number | The phone count of the registrant contact. | 
+| DomainTools.Identity.SOAEmail | String | The SOA record of the Email. | 
+| DomainTools.Identity.SSLCertificateEmail | String | The Email of the SSL certificate. | 
+| DomainTools.Identity.AdminContact.Country.value | String | The country value of the administrator contact. | 
+| DomainTools.Identity.AdminContact.Country.count | Number | The country count of the administrator contact. | 
+| DomainTools.Identity.AdminContact.Email.value | String | The Email value of the administrator contact. | 
+| DomainTools.Identity.AdminContact.Email.count | Number | The Email count of the administrator contact. | 
+| DomainTools.Identity.AdminContact.Name.value | String | The name value of the administrator contact. | 
+| DomainTools.Identity.AdminContact.Name.count | Number | The name count of the administrator contact. | 
+| DomainTools.Identity.AdminContact.Phone.value | String | The phone value of the administrator contact. | 
+| DomainTools.Identity.AdminContact.Phone.count | Number | The phone count of the administrator contact. | 
+| DomainTools.Identity.TechnicalContact.Country.value | String | The country value of the technical contact. | 
+| DomainTools.Identity.TechnicalContact.Country.count | Number | The country count of the technical contact. | 
+| DomainTools.Identity.TechnicalContact.Email.value | String | The Email value of the technical contact. | 
+| DomainTools.Identity.TechnicalContact.Email.count | Number | The Email count of the technical contact. | 
+| DomainTools.Identity.TechnicalContact.Name.value | String | The name value of the technical Contact. | 
+| DomainTools.Identity.TechnicalContact.Name.count | Number | The name count of the technical contact. | 
+| DomainTools.Identity.TechnicalContact.Phone.value | String | The phone value of the technical contact. | 
+| DomainTools.Identity.TechnicalContact.Phone.count | Number | The phone count of the technical contact. | 
+| DomainTools.Identity.BillingContact.Country.value | String | The country value of the billing contact. | 
+| DomainTools.Identity.BillingContact.Country.count | Number | The country count of the billing contact. | 
+| DomainTools.Identity.BillingContact.Email.value | String | The Email value of the billing contact. | 
+| DomainTools.Identity.BillingContact.Email.count | Number | The Email count of the billing contact. | 
+| DomainTools.Identity.BillingContact.Name.value | String | The name value of the billing contact. | 
+| DomainTools.Identity.BillingContact.Name.count | Number | The name count of the billing contact. | 
+| DomainTools.Identity.BillingContact.Phone.value | String | The phone value of the billing contact. | 
+| DomainTools.Identity.BillingContact.Phone.count | Number | The phone count of the billing contact. | 
+| DomainTools.Identity.EmailDomains | String | The Email Domains. | 
+| DomainTools.Identity.AdditionalWhoisEmails.value | String | The value of the Additional Whois Emails record. | 
+| DomainTools.Identity.AdditionalWhoisEmails.count | Number | The count of the Additional Whois Emails record. | 
+| DomainTools.Registration.DomainRegistrant | String | The registrant of the domain. | 
+| DomainTools.Registration.RegistrarStatus | String | The status of the registrar. | 
+| DomainTools.Registration.DomainStatus | Boolean | The active status of the domain. | 
+| DomainTools.Registration.CreateDate | Date | The date the domain was created. | 
+| DomainTools.Registration.ExpirationDate | Date | The expiration date of the domain. | 
+| DomainTools.Hosting.IPAddresses.address.value | String | The address value of IP addresses. | 
+| DomainTools.Hosting.IPAddresses.address.count | Number | The address count of IP addresses. | 
+| DomainTools.Hosting.IPAddresses.asn.value | String | The ASN value of IP addresses. | 
+| DomainTools.Hosting.IPAddresses.asn.count | Number | The ASN count of IP addresses. | 
+| DomainTools.Hosting.IPAddresses.country_code.value | String | The country code value of IP addresses. | 
+| DomainTools.Hosting.IPAddresses.country_code.count | Number | The country code count of IP addresses. | 
+| DomainTools.Hosting.IPAddresses.isp.value | String | The ISP value of IP addresses. | 
+| DomainTools.Hosting.IPAddresses.isp.count | Number | The ISP count of IP addresses. | 
+| DomainTools.Hosting.IPCountryCode | String | The country code of the IP address. | 
+| DomainTools.Hosting.MailServers.domain.value | String | The domain value of the Mail Servers. | 
+| DomainTools.Hosting.MailServers.domain.count | Number | The domain count of the Mail Servers. | 
+| DomainTools.Hosting.MailServers.host.value | String | The host value of the Mail Servers. | 
+| DomainTools.Hosting.MailServers.host.count | Number | The host count of the Mail Servers. | 
+| DomainTools.Hosting.MailServers.ip.value | String | The IP value of the Mail Servers. | 
+| DomainTools.Hosting.MailServers.ip.count | Number | The IP count of the Mail Servers. | 
+| DomainTools.Hosting.SPFRecord | String | The SPF Record. | 
+| DomainTools.Hosting.NameServers.domain.value | String | The domain value of the domain NameServers. | 
+| DomainTools.Hosting.NameServers.domain.count | Number | The domain count of the domain NameServers. | 
+| DomainTools.Hosting.NameServers.host.value | String | The host value of the domain NameServers. | 
+| DomainTools.Hosting.NameServers.host.count | Number | The host count of the domain NameServers. | 
+| DomainTools.Hosting.NameServers.ip.value | String | The IP value of the domain NameServers. | 
+| DomainTools.Hosting.NameServers.ip.count | Number | The IP count of domain NameServers. | 
+| DomainTools.Hosting.SSLCertificate.hash.value | String | The hash value of the SSL certificate. | 
+| DomainTools.Hosting.SSLCertificate.hash.count | Number | The hash count of the SSL certificate. | 
+| DomainTools.Hosting.SSLCertificate.organization.value | String | The organization value of the SSL certificate. | 
+| DomainTools.Hosting.SSLCertificate.organization.count | Number | The organization count of the SSL certificate information. | 
+| DomainTools.Hosting.SSLCertificate.subject.value | String | The subject value of the SSL certificate information. | 
+| DomainTools.Hosting.SSLCertificate.subject.count | Number | The subject count of the SSL certificate information. | 
+| DomainTools.Hosting.RedirectsTo.value | String | The Redirects To Value of the domain. | 
+| DomainTools.Hosting.RedirectsTo.count | Number | The Redirects To Count of the domain. | 
+| DomainTools.Analytics.GoogleAdsenseTrackingCode | Number | The tracking code of Google Adsense. | 
+| DomainTools.Analytics.GoogleAnalyticTrackingCode | Number | The tracking code of Google Analytics. | 
+| DomainTools.Domains.Analytics.GA4TrackingCode | Number | The tracking code of ga4. | 
+| DomainTools.Domains.Analytics.GTMTrackingCode | Number | The tracking code of gtm. | 
+| DomainTools.Domains.Analytics.FBTrackingCode | Number | The tracking code of fb. | 
+| DomainTools.Domains.Analytics.HotJarTrackingCode | Number | The tracking code of Hot Jar. | 
+| DomainTools.Domains.Analytics.BaiduTrackingCode | Number | The tracking code of Baidu. | 
+| DomainTools.Domains.Analytics.YandexTrackingCode | Number | The tracking code of Yandex. | 
+| DomainTools.Domains.Analytics.MatomoTrackingCode | Number | The tracking code of Matomo. | 
+| DomainTools.Domains.Analytics.StatcounterProjectTrackingCode | Number | The tracking code of Stat Counter Project. | 
+| DomainTools.Domains.Analytics.StatcounterSecurityTrackingCode | Number | The tracking code of Stat Counter Security. | 
+| DomainTools.WebsiteTitle | Number | The website title. | 
+| DomainTools.FirstSeen | Number | The date the domain was first seen. | 
+| DomainTools.ServerType | Number | The server type. | 
+| DBotScore.Indicator | String | The indicator of the DBotScore. | 
+| DBotScore.Type | String | The indicator type of the DBotScore. | 
+| DBotScore.Vendor | String | The vendor used to calculate the score. | 
+| DBotScore.Score | Number | The actual score. | 
+
+### domaintoolsiris-investigate
+
+***
+Returns a complete profile of the domain (SLD.TLD) using Iris Investigate. If parsing of FQDNs is desired, see domainExtractAndInvestigate.
+
+#### Base Command
+
+`domaintoolsiris-investigate`
 
 #### Input
 
@@ -756,7 +888,7 @@ The DomainTools Reverse Whois API provides a list of domain names that share the
 
 | **Argument Name** | **Description** | **Required** |
 | --- | --- | --- |
-| terms | (mandatory and default) List of one or more terms to search for in the Whois record, separated with the pipe character ( \| ). | Required | 
+| terms | (default) List of one or more terms to search for in the Whois record, separated with the pipe character ( \| ). | Required | 
 | exclude | Domain names with Whois records that match these terms will be excluded from the result set. Separate multiple terms with the pipe character ( \| ). | Optional | 
 | onlyHistoricScope | Show only historic records. Possible values are: true, false. Default is false. | Optional | 
 

--- a/Packs/DomainTools_Iris/Layouts/layoutscontainer-DomainTools_Iris_Indicator_Layout.json
+++ b/Packs/DomainTools_Iris/Layouts/layoutscontainer-DomainTools_Iris_Indicator_Layout.json
@@ -70,7 +70,7 @@
                             },
                             {
                                 "endCol": 2,
-                                "fieldId": "expirationdate",
+                                "fieldId": "domaintoolsirisexpirationdate",
                                 "height": 22,
                                 "id": "1ce6c6c0-6d0e-11ee-b1a9-4fdded761d69",
                                 "index": 3,

--- a/Packs/DomainTools_Iris/Scripts/AddDomainRiskScoreToContext/AddDomainRiskScoreToContext.yml
+++ b/Packs/DomainTools_Iris/Scripts/AddDomainRiskScoreToContext/AddDomainRiskScoreToContext.yml
@@ -19,6 +19,6 @@ outputs:
   description: The overall risk score of the domain.
 subtype: python3
 fromversion: 6.6.0
-dockerimage: demisto/python3:3.10.13.82467
+dockerimage: demisto/python3:3.10.13.83255
 tests:
 - No tests (auto formatted)

--- a/Packs/DomainTools_Iris/Scripts/AssociateIndicatorsToIncident/AssociateIndicatorsToIncident.yml
+++ b/Packs/DomainTools_Iris/Scripts/AssociateIndicatorsToIncident/AssociateIndicatorsToIncident.yml
@@ -12,6 +12,6 @@ timeout: '0'
 type: python
 subtype: python3
 fromversion: 6.6.0
-dockerimage: demisto/python3:3.10.13.82467
+dockerimage: demisto/python3:3.10.13.83255
 tests:
 - No tests (auto formatted)

--- a/Packs/DomainTools_Iris/Scripts/CheckLastEnrichment/CheckLastEnrichment.yml
+++ b/Packs/DomainTools_Iris/Scripts/CheckLastEnrichment/CheckLastEnrichment.yml
@@ -27,6 +27,6 @@ timeout: '0'
 type: python
 subtype: python3
 fromversion: 6.6.0
-dockerimage: demisto/python3:3.10.13.82467
+dockerimage: demisto/python3:3.10.13.83255
 tests:
 - No tests (auto formatted)

--- a/Packs/DomainTools_Iris/Scripts/CheckPivotableDomains/CheckPivotableDomains.yml
+++ b/Packs/DomainTools_Iris/Scripts/CheckPivotableDomains/CheckPivotableDomains.yml
@@ -168,6 +168,6 @@ tags:
 enabled: true
 subtype: python3
 fromversion: 6.6.0
-dockerimage: demisto/python3:3.10.13.82467
+dockerimage: demisto/python3:3.10.13.83255
 tests:
 - No tests (auto formatted)

--- a/Packs/DomainTools_Iris/Scripts/CheckTags/CheckTags.yml
+++ b/Packs/DomainTools_Iris/Scripts/CheckTags/CheckTags.yml
@@ -31,6 +31,6 @@ timeout: '0'
 type: python
 subtype: python3
 fromversion: 6.6.0
-dockerimage: demisto/python3:3.10.13.82467
+dockerimage: demisto/python3:3.10.13.83255
 tests:
 - No tests (auto formatted)

--- a/Packs/DomainTools_Iris/Scripts/DomainExtractAndEnrich/DomainExtractAndEnrich.yml
+++ b/Packs/DomainTools_Iris/Scripts/DomainExtractAndEnrich/DomainExtractAndEnrich.yml
@@ -333,6 +333,6 @@ timeout: '0'
 type: python
 subtype: python3
 fromversion: 6.6.0
-dockerimage: demisto/python3:3.10.13.82467
+dockerimage: demisto/python3:3.10.13.83255
 tests:
 - No tests (auto formatted)

--- a/Packs/DomainTools_Iris/Scripts/DomainExtractAndInvestigate/DomainExtractAndInvestigate.py
+++ b/Packs/DomainTools_Iris/Scripts/DomainExtractAndInvestigate/DomainExtractAndInvestigate.py
@@ -12,7 +12,7 @@ def main():
     domains = [domain['Contents'] for domain in res if 'Contents' in domain]
     parameters = ','.join(domains)
 
-    return_results(demisto.executeCommand('domain', {'domain': parameters, 'include_context': include_context}))
+    return_results(demisto.executeCommand('domaintoolsiris-investigate', {'domain': parameters, 'include_context': include_context}))
 
 
 if __name__ in ['__main__', '__builtin__', 'builtins']:

--- a/Packs/DomainTools_Iris/Scripts/DomainExtractAndInvestigate/DomainExtractAndInvestigate.py
+++ b/Packs/DomainTools_Iris/Scripts/DomainExtractAndInvestigate/DomainExtractAndInvestigate.py
@@ -12,7 +12,8 @@ def main():
     domains = [domain['Contents'] for domain in res if 'Contents' in domain]
     parameters = ','.join(domains)
 
-    return_results(demisto.executeCommand('domaintoolsiris-investigate', {'domain': parameters, 'include_context': include_context}))
+    return_results(
+        demisto.executeCommand('domaintoolsiris-investigate', {'domain': parameters, 'include_context': include_context}))
 
 
 if __name__ in ['__main__', '__builtin__', 'builtins']:

--- a/Packs/DomainTools_Iris/Scripts/DomainExtractAndInvestigate/DomainExtractAndInvestigate.yml
+++ b/Packs/DomainTools_Iris/Scripts/DomainExtractAndInvestigate/DomainExtractAndInvestigate.yml
@@ -332,6 +332,6 @@ timeout: '0'
 type: python
 subtype: python3
 fromversion: 6.6.0
-dockerimage: demisto/python3:3.10.13.82467
+dockerimage: demisto/python3:3.10.13.83255
 tests:
 - No tests (auto formatted)

--- a/Packs/DomainTools_Iris/Scripts/SetIndicatorTableData/SetIndicatorTableData.py
+++ b/Packs/DomainTools_Iris/Scripts/SetIndicatorTableData/SetIndicatorTableData.py
@@ -84,11 +84,11 @@ def set_indicator_table_data(args: dict[str, Any]) -> CommandResults:
             reputation = ReputationEnum.UNKNOWN
 
         riskscore_component_mapping = {
-            "proximity": domaintools_analytics_data.get("ProximityRiskScore") or "",
-            "malware": domaintools_analytics_data.get("MalwareRiskScore") or "",
-            "phishing": domaintools_analytics_data.get("PhishingRiskScore") or "",
-            "spam": domaintools_analytics_data.get("SpamRiskScore") or "",
-            "evidence": domaintools_analytics_data.get("ThreatProfileRiskScore", {}).get("Evidence") or ""
+            "ProximityRiskScore": domaintools_analytics_data.get("ProximityRiskScore") or "",
+            "MalwareRiskScore": domaintools_analytics_data.get("MalwareRiskScore") or "",
+            "PhishingRiskScore": domaintools_analytics_data.get("PhishingRiskScore") or "",
+            "SpamRiskScore": domaintools_analytics_data.get("SpamRiskScore") or "",
+            "ThreatProfileRiskScore": {"Evidence": domaintools_analytics_data.get("ThreatProfileRiskScore", {}).get("Evidence")} or ""
         }
 
         domaintools_iris_indicator = {
@@ -113,7 +113,7 @@ def set_indicator_table_data(args: dict[str, Any]) -> CommandResults:
             "domaintoolsirisregistrantorg": domaintools_identity_data.get("RegistrantOrg"),
             "registrantname": domaintools_identity_data.get("RegistrantName"),
             "domaintoolsirissoaemail": format_attribute(domaintools_identity_data.get("SOAEmail"), key="value"),
-            "expirationdate": domaintools_identity_data.get("Registration", {}).get("ExpirationDate"),
+            "domaintoolsirisexpirationdate": domaintools_data.get("Registration", {}).get("ExpirationDate"),
             "domaintoolsirisriskscorecomponents": riskscore_component_mapping
         }
 

--- a/Packs/DomainTools_Iris/Scripts/SetIndicatorTableData/SetIndicatorTableData.py
+++ b/Packs/DomainTools_Iris/Scripts/SetIndicatorTableData/SetIndicatorTableData.py
@@ -88,7 +88,8 @@ def set_indicator_table_data(args: dict[str, Any]) -> CommandResults:
             "MalwareRiskScore": domaintools_analytics_data.get("MalwareRiskScore") or "",
             "PhishingRiskScore": domaintools_analytics_data.get("PhishingRiskScore") or "",
             "SpamRiskScore": domaintools_analytics_data.get("SpamRiskScore") or "",
-            "ThreatProfileRiskScore": {"Evidence": domaintools_analytics_data.get("ThreatProfileRiskScore", {}).get("Evidence")} or ""
+            "ThreatProfileRiskScore": {"Evidence": domaintools_analytics_data.get("ThreatProfileRiskScore", {}).get(
+                "Evidence")} or ""
         }
 
         domaintools_iris_indicator = {

--- a/Packs/DomainTools_Iris/Scripts/SetIndicatorTableData/SetIndicatorTableData.yml
+++ b/Packs/DomainTools_Iris/Scripts/SetIndicatorTableData/SetIndicatorTableData.yml
@@ -40,6 +40,6 @@ timeout: '0'
 type: python
 subtype: python3
 fromversion: 6.6.0
-dockerimage: demisto/python3:3.10.13.82467
+dockerimage: demisto/python3:3.10.13.83255
 tests:
 - No tests (auto formatted)


### PR DESCRIPTION
* update domain command to have no extra parameters, match the docs to generic domain commands
* create  `domaintoolsiris-investigate` with the "include_context" param
* Map `DomainTools Iris` layout fields to indicator using IndicatorTypes. Note: the playbooks is still using the code to insert fields. But this change allows you to use the `DomainTools Iris` layout/indicator outside of the playbooks. I don't think this will be a use case, but it should satisfy the demo feedback. We can update both playbooks and individual indicator creation to use the mapping, but that will require a larger re-write of the commands, playbooks, and scripts.
* Fix some previous mapping bugs in the layout
* Fix validation errors

Loom video is in the ticket